### PR TITLE
Update of processclass_remote_example.py

### DIFF
--- a/zprocess/examples/processclass_remote_example.py
+++ b/zprocess/examples/processclass_remote_example.py
@@ -13,7 +13,7 @@
 
 from __future__ import print_function
 from zprocess import Process, ProcessTree
-import os
+
 
 """Before running this example program, you need to start a remote process server.
 Start one in a terminal with:
@@ -21,6 +21,8 @@ Start one in a terminal with:
     python -m zprocess.remote -tui
 
 then run this script.
+The example package 'remote_example_package' with the class 'Fo' must be present in
+the folder from where zprocess.remote is run.
 
 To test across multiple machines, set REMOTE_HOST below to the hostname of the other
 computer, and generate a shared secret and save it to file with:
@@ -47,16 +49,20 @@ else:
     shared_secret = None
 
 
+# The zprocess.remote server will remotely execute the Foo process below.
+"""
 class Foo(Process):
     def run(self, data):
-        print('this is a running foo in process %d' % os.getpid())
+        print('this is a running foo in process %d ' % os.getpid())
         print('data is', data)
         message = self.from_parent.get()
         print('foo, got a message:', message)
         self.to_parent.put('hello yourself!')
         import time
         time.sleep(1)
+"""
 
+REMOTE_CLASS = 'remote_example_package.Foo'
 
 # This __main__ check is important to stop the same code executing again in the child:
 if __name__ == '__main__':
@@ -64,7 +70,9 @@ if __name__ == '__main__':
     print("See comments in the script for instructions")
     process_tree = ProcessTree(shared_secret)
     remote_process_client = process_tree.remote_process_client(REMOTE_HOST)
-    foo = Foo(process_tree, remote_process_client=remote_process_client)
+    foo = Process(process_tree,
+                  remote_process_client=remote_process_client,
+                  subclass_fullname=REMOTE_CLASS)
     to_child, from_child = foo.start('bar')
     to_child.put('hello, foo!')
     response = from_child.get()

--- a/zprocess/examples/remote_example_package/__init__.py
+++ b/zprocess/examples/remote_example_package/__init__.py
@@ -1,0 +1,26 @@
+#####################################################################
+#                                                                   #
+# processclass_example.py                                           #
+#                                                                   #
+# Copyright 2024, Chris Billington                                  #
+#                                                                   #
+# This file is part of the zprocess project (see                    #
+# https://bitbucket.org/cbillington/zprocess) and is licensed under #
+# the Simplified BSD License. See the license.txt file in the root  #
+# of the project for the full license.                              #
+#                                                                   #
+#####################################################################
+
+from __future__ import print_function
+from zprocess import Process
+import os
+
+class Foo(Process):
+    def run(self, data):
+        print('this is a running foo in process %d ' % os.getpid())
+        print('data is', data)
+        message = self.from_parent.get()
+        print('foo, got a message:', message)
+        self.to_parent.put('hello yourself!')
+        import time
+        time.sleep(1)


### PR DESCRIPTION
While running the example script [processclass_remote_example.py](https://github.com/chrisjbillington/zprocess/blob/f367fda63775f2aa1ef1fd93ea962bb266ab1bc2/zprocess/examples/processclass_remote_example.py) I stumbled into the following error:

```
Traceback (most recent call last):
  File "C:\Users\arestell\OneDrive - University of Maryland\git\zprocess\zprocess\examples\processclass_remote_example.py", line 67, in <module>
    foo = Foo(process_tree, remote_process_client=remote_process_client)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\arestell\miniconda3\envs\synchro\Lib\site-packages\zprocess-0.1.dev561+gf367fda-py3.11.egg\zprocess\process_tree.py", line 1541, in __init__
    _Process.__init__(self, *args, **kwargs)
  File "C:\Users\arestell\miniconda3\envs\synchro\Lib\site-packages\zprocess-0.1.dev561+gf367fda-py3.11.egg\zprocess\process_tree.py", line 1007, in __init__
    raise RuntimeError(msg)
RuntimeError: Cannot start a remote process for a class defined in __main__. The remote process will not be able to import the required class as it will not know the import path. Either define the class in a different module importable on both systems, or use zprocess.Process directly, passing in subclass_fullname to specify the full import path.
```

Noticing that the class *Process* is (rightfully so!) performing some extra checks before opening a task in the remote server I modified the code by adding a remote package *remote_example_package* that the server can refer to.

After such modification the example runs without errors.

Here what I exactly do for running the example.

1) I start a remote server in a separate terminal by running:

```bash
python -m zprocess.remote -tui
```

2) In the current terminal I run:

```bash
python processclass_remote_example.py
```

A typical output is:

```
Note: script will not work without starting a zprocess.remote server.
See comments in the script for instructions
this is a running foo in process 20268
parent, got a response: hello yourself!
data is bar
foo, got a message: hello, foo!
here
```

however, as expected, due to the presence of some asynchronous tasks the messages can be written in a different order such as this:

```
Note: script will not work without starting a zprocess.remote server.
See comments in the script for instructions
parent, got a response: hello yourself!
this is a running foo in process 12804
data is bar
foo, got a message: hello, foo!
here
```

I hope that what I'm doing in the example represents a correct use case for zprocess.remote