### PR TITLE
Bug fixes

### DIFF
--- a/tests/test_zlock_server.py
+++ b/tests/test_zlock_server.py
@@ -681,6 +681,60 @@ class ImplementationUnitTests(unittest.TestCase):
 
 
 class OtherTests(unittest.TestCase):
+    def test_default_bind_address(self):
+        class FakeSocket(object):
+            def __init__(self):
+                self.logger = None
+
+            def bind_to_random_port(self, addr):
+                self.bound_addr = addr
+                return 7339
+
+            def bind(self, endpoint):
+                self.endpoint = endpoint
+
+            def close(self):
+                pass
+
+        class FakeContext(object):
+            def __init__(self):
+                self.sockets = []
+
+            def socket(self, *args, **kwargs):
+                sock = FakeSocket()
+                self.sockets.append(sock)
+                return sock
+
+        class FakePoller(object):
+            def register(self, *args, **kwargs):
+                pass
+
+        class FakeAllowInterrupt(object):
+            def __init__(self, handler):
+                self.handler = handler
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+        class FakeLogger(object):
+            def info(self, *args, **kwargs):
+                pass
+
+        fake_context = FakeContext()
+        server = ZMQLockServer(silent=True)
+
+        with monkeypatch(zprocess.zlock.server.SecureContext, 'instance', lambda *args, **kwargs: fake_context):
+            with monkeypatch(zprocess.zlock.server.zmq, 'Poller', FakePoller):
+                with monkeypatch(zprocess.zlock.server, 'allow_interrupt', FakeAllowInterrupt):
+                    with monkeypatch(zprocess.zlock.server, 'setup_logging', lambda *args, **kwargs: FakeLogger()):
+                        with monkeypatch(ZMQLockServer, '_mainloop', lambda self: None):
+                            server.run()
+
+        self.assertEqual(fake_context.sockets[0].bound_addr, 'tcp://*')
+
     def test_bind_to_port(self):
         # Run the server on a random port on localhost:
         import random

--- a/tests/test_zlock_server.py
+++ b/tests/test_zlock_server.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 import time
+import threading
 import zmq
 import unittest
 
@@ -28,6 +29,7 @@ from zprocess.zlock.server import (
     ERR_TIMEOUT_INVALID,
     ERR_READ_ONLY_WRONG,
 )
+from zprocess.zlock import ZLockClient
 import zprocess.zlock.server
 
 
@@ -678,6 +680,37 @@ class ImplementationUnitTests(unittest.TestCase):
         # Can't give up if not waiting:
         with self.assertRaises(NotWaiting):
             lock.give_up(b'client_foo')
+
+    def test_zlock_client_uses_instance_default_timeout(self):
+        class FakeSocket(object):
+            def __init__(self):
+                self.messages = []
+
+            def send_multipart(self, message, flags=0):
+                self.messages.append(message)
+
+            def recv(self):
+                return b'ok'
+
+            def close(self, linger=False):
+                pass
+
+        class FakePoller(object):
+            def poll(self, timeout):
+                return [object()]
+
+        client = ZLockClient(default_timeout=12.5)
+        client.local = threading.local()
+
+        def fake_new_socket(timeout=None):
+            client.local.sock = FakeSocket()
+            client.local.poller = FakePoller()
+            client.local.client_id = b'client'
+
+        client._new_socket = fake_new_socket
+        client.acquire('key_foo')
+
+        self.assertEqual(client.local.sock.messages[-1][3], b'12.5')
 
 
 class OtherTests(unittest.TestCase):

--- a/tests/test_zlock_server.py
+++ b/tests/test_zlock_server.py
@@ -29,6 +29,7 @@ from zprocess.zlock.server import (
     ERR_TIMEOUT_INVALID,
     ERR_READ_ONLY_WRONG,
 )
+import zprocess.zlock as zlock
 from zprocess.zlock import ZLockClient
 import zprocess.zlock.server
 
@@ -711,6 +712,19 @@ class ImplementationUnitTests(unittest.TestCase):
         client.acquire('key_foo')
 
         self.assertEqual(client.local.sock.messages[-1][3], b'12.5')
+
+    def test_set_client_thread_name_requires_default_client(self):
+        with monkeypatch(zlock, '_default_zlock_client', None):
+            with self.assertRaisesRegex(RuntimeError, 'ZLockClient'):
+                zlock.set_client_thread_name('worker')
+
+    def test_set_client_thread_name_delegates_to_default_client(self):
+        client = ZLockClient()
+        with monkeypatch(zlock, '_default_zlock_client', client):
+            zlock.set_client_thread_name('worker')
+
+        self.assertEqual(client.thread_name.name, 'worker')
+        self.assertIn(b'worker-', client.local.client_id)
 
 
 class OtherTests(unittest.TestCase):

--- a/tests/test_zlock_server.py
+++ b/tests/test_zlock_server.py
@@ -726,6 +726,15 @@ class ImplementationUnitTests(unittest.TestCase):
         self.assertEqual(client.thread_name.name, 'worker')
         self.assertIn(b'worker-', client.local.client_id)
 
+    def test_set_client_process_name_avoids_double_separator(self):
+        client = ZLockClient()
+        with monkeypatch(zlock, '_default_zlock_client', client):
+            zlock.set_client_process_name('worker')
+
+        process_identifier = client._make_client_id().split(':')[1]
+        self.assertTrue(process_identifier.startswith('worker-'))
+        self.assertNotIn('worker--', process_identifier)
+
 
 class OtherTests(unittest.TestCase):
     def test_default_bind_address(self):

--- a/tests/test_zprocess.py
+++ b/tests/test_zprocess.py
@@ -5,6 +5,7 @@ import os
 import time
 import threading
 import subprocess
+from unittest.mock import patch
 
 import zmq
 import pytest
@@ -408,6 +409,64 @@ class TaskTests(unittest.TestCase):
 
 
 class ClientServerTests(unittest.TestCase):
+
+    def test_invalid_dtype_server_raises_valueerror(self):
+        class InvalidServer(clientserver._ZMQServer):
+            def setup_auth(self, context):
+                return None
+
+        class FakeSocket(object):
+            def setsockopt(self, *args, **kwargs):
+                pass
+
+            def bind(self, *args, **kwargs):
+                pass
+
+            def close(self, *args, **kwargs):
+                pass
+
+        class FakeContext(object):
+            def socket(self, *args, **kwargs):
+                return FakeSocket()
+
+        class FakePoller(object):
+            def register(self, *args, **kwargs):
+                pass
+
+        with patch.object(clientserver.zmq, 'Context', FakeContext):
+            with patch.object(clientserver.zmq, 'Poller', FakePoller):
+                with self.assertRaisesRegex(ValueError, "invalid dtype invalid"):
+                    InvalidServer(
+                        port=1, dtype='invalid', bind_address='tcp://127.0.0.1'
+                    )
+
+    def test_invalid_dtype_sender_raises_valueerror(self):
+        class FakeSocket(object):
+            def setsockopt(self, *args, **kwargs):
+                pass
+
+            def connect(self, *args, **kwargs):
+                pass
+
+            def close(self, *args, **kwargs):
+                pass
+
+        class FakeContext(object):
+            def socket(self, *args, **kwargs):
+                return FakeSocket()
+
+        class FakePoller(object):
+            def register(self, *args, **kwargs):
+                pass
+
+        sender = clientserver._Sender(
+            dtype='invalid', interruptor=clientserver.Interruptor()
+        )
+
+        with patch.object(clientserver.SecureContext, 'instance', return_value=FakeContext()):
+            with patch.object(clientserver.zmq, 'Poller', FakePoller):
+                with self.assertRaisesRegex(ValueError, "invalid dtype invalid"):
+                    sender.new_socket('localhost', 1)
 
     def test_rep_server(self):
         class MyServer(ZMQServer):

--- a/tests/test_zprocess.py
+++ b/tests/test_zprocess.py
@@ -4,6 +4,7 @@ import sys
 import os
 import time
 import threading
+import subprocess
 
 import zmq
 import pytest
@@ -204,6 +205,23 @@ class ProcessClassTests(unittest.TestCase):
     def tearDown(self):
         self.process.terminate()
         self.redirection_sock.close()
+
+
+class ProcessTerminateTests(unittest.TestCase):
+    def test_terminate_ignores_local_wait_timeout(self):
+        class DummyChild(object):
+            def terminate(self, **kwargs):
+                pass
+
+            def wait(self, timeout=None, **kwargs):
+                raise subprocess.TimeoutExpired(cmd='dummy', timeout=timeout)
+
+        process = Process.__new__(Process)
+        process.child = DummyChild()
+        process.interrupt_startup = lambda reason=None: None
+
+        # Should not leak subprocess.TimeoutExpired for a local child wait timeout:
+        process.terminate(wait_timeout=0.1)
 
 
 class HeartbeatClientTestProcess(Process):

--- a/zprocess/clientserver.py
+++ b/zprocess/clientserver.py
@@ -129,8 +129,10 @@ class ZMQServer(object):
                                 protocol=zprocess.PICKLE_PROTOCOL)
             self.recv = self.sock.recv_pyobj
         else:
-            msg = ("invalid dtype %s, must be 'raw', 'string', " +
-                   "'multipart' or 'pyobj'" % str(self.dtype))
+            msg = (
+                "invalid dtype %s, must be 'raw', 'string', "
+                "'multipart' or 'pyobj'"
+            ) % str(self.dtype)
             raise ValueError(msg)
             
         self.mainloop_thread = threading.Thread(target=self.mainloop)
@@ -318,8 +320,8 @@ class _Sender(object):
             else:
                 msg = (
                     "invalid dtype %s, must be 'raw', 'string', "
-                    + "'multipart' or 'pyobj'" % str(self.dtype)
-                )
+                    "'multipart' or 'pyobj'"
+                ) % str(self.dtype)
                 raise ValueError(msg)
         except:
             # Didn't work, don't keep it:
@@ -474,4 +476,3 @@ zmq_push_raw = _default_client.push_raw
 __all__ = ['ZMQServer', 'ZMQClient',
            'zmq_get', 'zmq_get_multipart', 'zmq_get_string', 'zmq_get_raw',
            'zmq_push', 'zmq_push_multipart', 'zmq_push_string', 'zmq_push_raw']
-

--- a/zprocess/process_tree.py
+++ b/zprocess/process_tree.py
@@ -1129,7 +1129,7 @@ class Process(object):
             try:
                 self.child.terminate(**kwargs)
                 self.child.wait(timeout=wait_timeout, **kwargs)
-            except (OSError, TimeoutError):
+            except (OSError, TimeoutError, subprocess.TimeoutExpired):
                 # process is already dead, or cannot contact remote server
                 pass
 

--- a/zprocess/zlock/__init__.py
+++ b/zprocess/zlock/__init__.py
@@ -121,7 +121,7 @@ class ZLockClient(object):
 
     def acquire(self, key, timeout=None, read_only=False):
         if timeout is None:
-            timeout = DEFAULT_TIMEOUT
+            timeout = self.default_timeout
         timeout = str(timeout).encode('utf8')
         if not hasattr(self.local, 'sock'):
             self._new_socket()

--- a/zprocess/zlock/__init__.py
+++ b/zprocess/zlock/__init__.py
@@ -299,8 +299,8 @@ def set_client_process_name(name):
 
 def set_client_thread_name(name):
     """Deprecated. Instantiate a ZLockClient and call its method instead"""
-    if _default_zlock_client is not None:
-        raise RuntimeError("Can't set thread name before instantiating ZLogClient")
+    if _default_zlock_client is None:
+        raise RuntimeError("Can't set thread name before instantiating ZLockClient")
     _default_zlock_client.set_thread_name(name)
 
 

--- a/zprocess/zlock/__init__.py
+++ b/zprocess/zlock/__init__.py
@@ -289,7 +289,6 @@ def set_default_timeout(timeout):
 
 def set_client_process_name(name):
     """Deprecated. Instantiate a ZLockClient and call its method instead"""
-    name += '-'
     global _process_name
     if _default_zlock_client is not None:
         _default_zlock_client.set_process_name(name)

--- a/zprocess/zlock/server.py
+++ b/zprocess/zlock/server.py
@@ -421,7 +421,7 @@ class ZMQLockServer(object):
     def __init__(
         self,
         port=None,
-        bind_address='tcp:/*',
+        bind_address='tcp://*',
         silent=False,
         shared_secret=None,
         allow_insecure=True,


### PR DESCRIPTION
The branch fixes a number of small bugs as documented in the commit history.  In brief this fixes:

```
Fix Process.terminate timeout handling
Fix default bind address in zlock server
Honor ZLockClient default timeout
Fix deprecated zlock thread-name helper
Fix deprecated zlock process-name helper
Fix invalid dtype error formatting
```

Note: the bugs were found and fixed by CODEX, but the changes were all verified by me.